### PR TITLE
Configure backend CORS for Cloudflare Workers integration

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -100,14 +100,23 @@ The frontend is deployed as a Cloudflare Worker with:
 - **Security Headers**: Automatic security headers for all responses
 - **Caching**: Optimized caching for static assets vs HTML
 
-### 3. Update Backend CORS
+### 4. Update Backend CORS
 
 After frontend deployment:
 
-1. Go back to Render Dashboard
-2. Edit your backend service environment variables
-3. Set `FRONTEND_URL` to your Cloudflare Pages URL
-4. Redeploy the backend service
+1. **Get your Cloudflare Workers URL** (e.g., `https://starter-webapp-frontend.your-subdomain.workers.dev`)
+
+2. **Update Render Backend Environment Variables**:
+   - Go to Render Dashboard → Your backend service → Environment
+   - Set `FRONTEND_URL` to your Workers URL
+   - Optionally set `CLOUDFLARE_WORKERS_URL` to the same URL
+   - Example: `FRONTEND_URL=https://starter-webapp-frontend.your-subdomain.workers.dev`
+
+3. **Redeploy the backend service** (or it will auto-redeploy on environment change)
+
+4. **Verify CORS is working**:
+   - Check backend logs for: `🔗 CORS Allowed Origins: [...]`
+   - Should include your Workers URL in the list
 
 ## Testing Full-Stack Deployment
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,7 +13,8 @@ FRONTEND_URL=http://localhost:5173
 # DATABASE_URL=postgresql://username:password@hostname:port/database
 # ENVIRONMENT=production
 # DEBUG=false
-# FRONTEND_URL=https://your-frontend.pages.dev
+# FRONTEND_URL=https://your-frontend.workers.dev
+# CLOUDFLARE_WORKERS_URL=https://starter-webapp-frontend.your-subdomain.workers.dev
 
 # Optional: API Configuration
 API_PREFIX=/api

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,5 +28,14 @@ class Settings:
             production_origin = os.getenv("FRONTEND_URL")
             if production_origin:
                 self.ALLOWED_ORIGINS.append(production_origin)
+            
+            # Also check for specific Cloudflare URL
+            cloudflare_url = os.getenv("CLOUDFLARE_WORKERS_URL")
+            if cloudflare_url:
+                self.ALLOWED_ORIGINS.append(cloudflare_url)
+        
+        # Remove duplicates and print for debugging
+        self.ALLOWED_ORIGINS = list(set(self.ALLOWED_ORIGINS))
+        print(f"🔗 CORS Allowed Origins: {self.ALLOWED_ORIGINS}")
 
 settings = Settings()


### PR DESCRIPTION
### CORS Configuration Updates
- Enhanced config.py to support multiple frontend URL environment variables
- Added CLOUDFLARE_WORKERS_URL environment variable support
- Added debug logging to show configured CORS origins
- Updated .env.example with Workers URL examples

### Documentation Updates
- Updated DEPLOYMENT.md with CORS configuration instructions
- Added step-by-step guide for setting environment variables in Render
- Included verification steps to confirm CORS is working

### Usage
Set either FRONTEND_URL or CLOUDFLARE_WORKERS_URL (or both) in Render:
- FRONTEND_URL=https://starter-webapp-frontend.your-subdomain.workers.dev
- Backend will automatically include this in CORS allowed origins
- Debug output will show configured origins in backend logs