### PR TITLE
Fix Cloudflare Workers environment variables for production

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         working-directory: frontend
-        run: npx wrangler deploy
+        run: npx wrangler deploy --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,13 @@ dist
 dist-ssr
 *.local
 
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "start": "vite preview --port 5173",
-    "deploy": "npx wrangler deploy",
+    "deploy": "npx wrangler deploy --env production",
     "deploy:dev": "npx wrangler deploy --env development",
     "deploy:preview": "npx wrangler deploy --env preview"
   },

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -7,9 +7,6 @@ main = "src/worker.js"
 directory = "dist"
 binding = "ASSETS"
 
-# Build configuration
-[build]
-command = "npm ci && npm run build && npm run build:worker"
 
 # Environment variables
 [vars]


### PR DESCRIPTION
### Environment Variable Fixes
- Remove build command from wrangler.toml (handled by GitHub Actions)
- Add --env production flag to wrangler deploy commands
- Update package.json deploy script to use production environment
- Add .env files to .gitignore to prevent local dev config override

### Root Cause
The .env file with VITE_API_URL=http://localhost:8000 was overriding
the production environment variables set in GitHub Actions build step.

### Result
Cloudflare Workers deployment will now show:
- Environment: PRODUCTION
- API URL: https://starter-webapp-backend.onrender.com

Instead of development localhost values.