### PR TITLE
Fix CORS trailing slash issue and add debugging

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -108,9 +108,10 @@ After frontend deployment:
 
 2. **Update Render Backend Environment Variables**:
    - Go to Render Dashboard → Your backend service → Environment
-   - Set `FRONTEND_URL` to your Workers URL
+   - Set `FRONTEND_URL` to your Workers URL **without trailing slash**
    - Optionally set `CLOUDFLARE_WORKERS_URL` to the same URL
    - Example: `FRONTEND_URL=https://starter-webapp-frontend.your-subdomain.workers.dev`
+   - ⚠️ **Important**: Do NOT include trailing slash (/) at the end
 
 3. **Redeploy the backend service** (or it will auto-redeploy on environment change)
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,12 +27,21 @@ class Settings:
         if self.ENVIRONMENT == "production":
             production_origin = os.getenv("FRONTEND_URL")
             if production_origin:
-                self.ALLOWED_ORIGINS.append(production_origin)
+                # Normalize URL - remove trailing slash and add both versions
+                normalized_url = production_origin.rstrip('/')
+                self.ALLOWED_ORIGINS.extend([
+                    normalized_url,           # without trailing slash
+                    normalized_url + '/'      # with trailing slash
+                ])
             
             # Also check for specific Cloudflare URL
             cloudflare_url = os.getenv("CLOUDFLARE_WORKERS_URL")
             if cloudflare_url:
-                self.ALLOWED_ORIGINS.append(cloudflare_url)
+                normalized_cf_url = cloudflare_url.rstrip('/')
+                self.ALLOWED_ORIGINS.extend([
+                    normalized_cf_url,        # without trailing slash
+                    normalized_cf_url + '/'   # with trailing slash
+                ])
         
         # Remove duplicates and print for debugging
         self.ALLOWED_ORIGINS = list(set(self.ALLOWED_ORIGINS))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.base import BaseHTTPMiddleware
 from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.db.database import get_db
@@ -7,6 +8,24 @@ from app.db.models import User
 
 app = FastAPI(title="Starter Web App API", version="1.0.0")
 
+class CORSDebugMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        origin = request.headers.get("origin")
+        if origin:
+            print(f"🌐 CORS Request from origin: '{origin}'")
+            print(f"🔍 Allowed origins: {settings.ALLOWED_ORIGINS}")
+            if origin in settings.ALLOWED_ORIGINS:
+                print(f"✅ Origin '{origin}' is allowed")
+            else:
+                print(f"❌ Origin '{origin}' is NOT in allowed list")
+        
+        response = await call_next(request)
+        return response
+
+# Add CORS debugging middleware first
+app.add_middleware(CORSDebugMiddleware)
+
+# Then add the actual CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_ORIGINS,


### PR DESCRIPTION
### CORS Trailing Slash Fix
- Enhanced config.py to add both URL versions (with and without trailing slash)
- Normalize URLs by stripping trailing slashes and adding both variants
- This handles the exact match requirement for CORS origins

### Enhanced CORS Debugging
- Added CORSDebugMiddleware to log incoming origin headers
- Shows which origins are allowed vs requested in backend logs
- Helps identify exact CORS mismatch issues

### Documentation Update
- Added warning about trailing slash in DEPLOYMENT.md
- Clear instruction to set FRONTEND_URL without trailing slash

### Issue Resolution
Backend showed: 'https://starter-webapp-frontend.binit-mohanty.workers.dev/'
Browser sends: 'https://starter-webapp-frontend.binit-mohanty.workers.dev'
The trailing slash mismatch was causing CORS rejection.

Now both versions are allowed and debugging shows exact origin matching.