### PR TITLE
Fix import error for BaseHTTPMiddleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.db.database import get_db


### PR DESCRIPTION
Changed import from fastapi.middleware.base to starlette.middleware.base
to resolve ModuleNotFoundError when importing the FastAPI application.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>