### PR TITLE
Fix build command to set environment variables during build

### DIFF
--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -9,7 +9,7 @@ binding = "ASSETS"
 
 # Build configuration
 [build]
-command = "npm install && npm run build && npm run build:worker"
+command = "npm install && VITE_API_URL=https://starter-webapp-backend.onrender.com VITE_ENVIRONMENT=production npm run build && npm run build:worker"
 
 # Default environment variables (production)
 [vars]


### PR DESCRIPTION
Modified wrangler.toml build command to explicitly set VITE_API_URL and
VITE_ENVIRONMENT during the build process, ensuring production values are
baked into the JavaScript bundle instead of development defaults.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>